### PR TITLE
Adds support for exists operator in FHIR enableWhen condition

### DIFF
--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -77,7 +77,7 @@ extension Coding {
         }
         
         switch fhirOperator {
-        case .exists, .equal:
+        case .equal:
             let matchingPattern = "^(?!\(matchValue)).*$"
             return ORKResultPredicate.predicateForChoiceQuestionResult(with: resultSelector, matchingPattern: matchingPattern)
         default:
@@ -93,6 +93,9 @@ extension FHIRPrimitive where PrimitiveType == FHIRBool {
         }
         
         switch fhirOperator {
+        case .exists:
+            let nilCheckPredicate = ORKResultPredicate.predicateForNilQuestionResult(with: resultSelector)
+            return booleanValue ? nilCheckPredicate : NSCompoundPredicate(notPredicateWithSubpredicate: nilCheckPredicate)
         case .equal:
             return ORKResultPredicate.predicateForBooleanQuestionResult(
                 with: resultSelector,


### PR DESCRIPTION
This PR allows Questionnaire.item.enableWhen to use the [exists operator](https://build.fhir.org/codesystem-questionnaire-enable-operator.html#questionnaire-enable-operator-exists), which must have a boolean value. 
"Exists" is considered to be true when the specified question has not been skipped.