### PR TITLE
Sets QuestionnaireResponse identifier and questionnaire reference

### DIFF
--- a/Sources/FHIRQuestionaires/Resources/IceCreamExample.json
+++ b/Sources/FHIRQuestionaires/Resources/IceCreamExample.json
@@ -4,6 +4,7 @@
   "language": "en-US",
   "status": "draft",
   "publisher": "CardinalKit",
+  "url": "http://cardinalkit.org/questionnaires/ice-cream",
   "meta": {
     "profile": [
       "http://cardinalkit.org/fhir/StructureDefinition/sdf-Questionnaire"

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/FHIRToResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/FHIRToResearchKit.swift
@@ -18,7 +18,7 @@ import ResearchKit
 /// An error that is thrown when translating a FHIR `Questionnaire` to an `ORKNavigableOrderedTask`
 public enum FHIRToResearchKitConversionError: Error, CustomStringConvertible {
     case noItems
-    case noId
+    case noURL
     case unsupportedOperator(QuestionnaireItemOperator)
     case unsupportedAnswer(QuestionnaireItemEnableWhen.AnswerX)
     case noOptions
@@ -29,8 +29,8 @@ public enum FHIRToResearchKitConversionError: Error, CustomStringConvertible {
         switch self {
         case .noItems:
             return "The parsed FHIR Questionaire didn't contain any items"
-        case .noId:
-            return "This FHIR Questionnaire does not have an id"
+        case .noURL:
+            return "This FHIR Questionnaire does not have a URL"
         case let .unsupportedOperator(fhirOperator):
             return "An unsupported operator was used: \(fhirOperator)"
         case let .unsupportedAnswer(answer):
@@ -73,7 +73,7 @@ extension ORKNavigableOrderedTask {
 
         // The task ID is set to the canonical URL of the questionnaire
         guard let id = questionnaire.url?.value?.url.absoluteString else {
-            throw FHIRToResearchKitConversionError.noId
+            throw FHIRToResearchKitConversionError.noURL
         }
 
         // Convert each FHIR Questionnaire Item to an ORKStep

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/FHIRToResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/FHIRToResearchKit.swift
@@ -71,7 +71,8 @@ extension ORKNavigableOrderedTask {
             throw FHIRToResearchKitConversionError.noItems
         }
 
-        guard let id = questionnaire.id?.value?.string else {
+        // The task ID is set to the canonical URL of the questionnaire
+        guard let id = questionnaire.url?.value?.url.absoluteString else {
             throw FHIRToResearchKitConversionError.noId
         }
 
@@ -84,6 +85,7 @@ extension ORKNavigableOrderedTask {
         }
 
         self.init(identifier: id, steps: steps)
+        
         // If any questions have defined skip logic, convert to ResearchKit navigation rules
         try constructNavigationRules(questions: item)
     }

--- a/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ResearchKitToFHIR.swift
+++ b/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ResearchKitToFHIR.swift
@@ -19,7 +19,8 @@ extension ORKTaskResult {
     public var fhirResponses: QuestionnaireResponse {
         var questionnaireResponses: [QuestionnaireResponseItem] = []
         let taskResults = self.results as? [ORKStepResult] ?? []
-        let id = self.identifier
+        let questionnaireID = self.identifier // a URL representing the questionnaire answered
+        let questionnaireResponseID = UUID().uuidString // a unique identifier for this set of answers
         
         for result in taskResults.compactMap(\.results).flatMap({ $0 }) {
             let response = createResponse(result)
@@ -30,8 +31,12 @@ extension ORKTaskResult {
 
         let questionnaireResponse = QuestionnaireResponse(status: FHIRPrimitive(QuestionnaireResponseStatus.completed))
         questionnaireResponse.item = questionnaireResponses
-        questionnaireResponse.id = FHIRPrimitive(FHIRString(id))
+        questionnaireResponse.id = FHIRPrimitive(FHIRString(questionnaireResponseID))
         questionnaireResponse.authored = FHIRPrimitive(try? DateTime(date: Date()))
+
+        if let questionnaireURL = URL(string: questionnaireID) {
+            questionnaireResponse.questionnaire = FHIRPrimitive(Canonical(questionnaireURL))
+        }
 
         return questionnaireResponse
     }


### PR DESCRIPTION
The `id` property on `QuestionnaireResponse` should be a unique identifier for this set of answers and the `questionnaire` property should contain the URL of the questionnaire from which these answers were derived.