### PR TITLE
ResearchKit on ARM, Update Example App Layout, and Fix README

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -65,12 +65,12 @@
 			isa = PBXGroup;
 			children = (
 				65545D0428BEBC57000C70E4 /* ExampleApp.swift */,
+				27E00A5928C13AF100AF17BC /* QuestionnaireListView.swift */,
+				27E00A5728C13ABE00AF17BC /* QuestionnaireView.swift */,
 				65545D0528BEBC57000C70E4 /* ORKOrderedTaskView.swift */,
 				65545D0628BEBC58000C70E4 /* ORKTaskFHIRDelegate.swift */,
 				654BD47F28BEBA8400B012D2 /* Assets.xcassets */,
 				65545D0C28BEBEBB000C70E4 /* Localizable.strings */,
-				27E00A5728C13ABE00AF17BC /* QuestionnaireView.swift */,
-				27E00A5928C13AF100AF17BC /* QuestionnaireListView.swift */,
 			);
 			path = ExampleApp;
 			sourceTree = "<group>";

--- a/Example/ExampleApp/Localizable.strings
+++ b/Example/ExampleApp/Localizable.strings
@@ -6,7 +6,6 @@
  SPDX-License-Identifier: MIT
 */
 
-"TITLE" = "ResearchKitOnFHIR Example";
-"START_QUESTIONNAIRE" = "Start ResearchKitOnFHIR Questionaire";
+"QUESTIONNAIRE_LIST_TITLE" = "Questionnaires";
+"QUESTIONNAIRE_LIST_EXAMPLES_HEADER" = "ResearchKit On FHIR Examples";
 "ERROR_MESSAGE" = "Could not load the FHIR-based questionnaire. Please check your JSON file or any errors thrown during the decoding.";
-"QUESTIONNAIRE_LIST_HEADER" = "Example FHIR Questionnaires";

--- a/Example/ExampleApp/QuestionnaireListView.swift
+++ b/Example/ExampleApp/QuestionnaireListView.swift
@@ -7,39 +7,34 @@
 //
 
 import SwiftUI
-import ResearchKit
-import ModelsR4
+import FHIRQuestionnaires
+
 
 /// List of example FHIR questionnaires to be rendered as ResearchKit tasks
 struct QuestionnaireListView: View {
     @State private var presentQuestionnaire = false
     @State private var activeQuestionnaire: Questionnaire?
     
-    private let exampleQuestionnaires: [Questionnaire] = [
-        .skipLogicExample,
-        .textValidationExample,
-        .containedValueSetExample
-    ]
     
     var body: some View {
-        VStack {
-            Text("TITLE")
+        NavigationView {
             List {
                 Section {
-                    ForEach(exampleQuestionnaires, id: \.self) { questionnaire in
+                    ForEach(Questionnaire.allQuestionnaires, id: \.self) { questionnaire in
                         Button(questionnaire.title?.value?.string ?? "Untitled Questionnaire") {
                             activeQuestionnaire = questionnaire
                             presentQuestionnaire = true
                         }
                     }
                 } header: {
-                    Text("QUESTIONNAIRE_LIST_HEADER")
+                    Text("QUESTIONNAIRE_LIST_EXAMPLES_HEADER")
                 }
             }
+                .navigationTitle("QUESTIONNAIRE_LIST_TITLE")
         }
-        .sheet(isPresented: $presentQuestionnaire) {
-            QuestionnaireView(questionnaire: self.$activeQuestionnaire)
-        }
+            .sheet(isPresented: $presentQuestionnaire) {
+                QuestionnaireView(questionnaire: self.$activeQuestionnaire)
+            }
     }
 }
 

--- a/Example/ExampleApp/QuestionnaireView.swift
+++ b/Example/ExampleApp/QuestionnaireView.swift
@@ -10,21 +10,11 @@ import SwiftUI
 import ResearchKit
 import ModelsR4
 
+
 /// Renders a ResearchKit task from the selected FHIR questionnaire
 struct QuestionnaireView: View {
     @Binding var questionnaire: Questionnaire?
-
-    /// Creates a ResearchKit navigable task from a FHIR questionnaire
-    /// - Parameter questionnaire: a FHIR questionnaire
-    /// - Returns: a ResearchKit navigable task
-    func createTask(questionnaire: Questionnaire) -> ORKNavigableOrderedTask? {
-        do {
-            return try ORKNavigableOrderedTask(questionnaire: questionnaire)
-        } catch {
-            print("Error creating task: \(error)")
-        }
-        return nil
-    }
+    
 
     var body: some View {
         if let activeQuestionnaire = questionnaire,
@@ -33,5 +23,18 @@ struct QuestionnaireView: View {
         } else {
             Text("ERROR_MESSAGE")
         }
+    }
+    
+    
+    /// Creates a ResearchKit navigable task from a FHIR questionnaire
+    /// - Parameter questionnaire: a FHIR questionnaire
+    /// - Returns: a ResearchKit navigable task
+    private func createTask(questionnaire: Questionnaire) -> ORKNavigableOrderedTask? {
+        do {
+            return try ORKNavigableOrderedTask(questionnaire: questionnaire)
+        } catch {
+            print("Error creating task: \(error)")
+        }
+        return nil
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "FHIRQuestionnaires", targets: ["FHIRQuestionnaires"])
     ],
     dependencies: [
-        .package(url: "https://github.com/PSchmiedmayer/ResearchKit.git", from: "2.1.1"),
+        .package(url: "https://github.com/PSchmiedmayer/ResearchKit.git", from: "2.1.2"),
         .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMajor(from: "0.4.0"))
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ ResearchKitOnFHIR can be installed into your Xcode project using [Swift Package 
 The `Example` directory contains an Xcode project that demonstrates how to create a ResearchKit task from a FHIR Questionnaire, and extract the results in the form of a FHIR QuestionnaireResponse.
 
 ## License
-This project is licensed under the MIT License. See [Licenses](https://github.com/CardinalKit/ResearchKitOnFHIR/tree/develop/LICENSES) for more information.
+This project is licensed under the MIT License. See [Licenses](https://github.com/CardinalKit/ResearchKitOnFHIR/tree/main/LICENSES) for more information.
 
 ## Contributors
-- Vishnu Ravi (vishnur@stanford.edu)
-- Paul Schmiedmayer (schmiedmayer@stanford.edu)
+This project is developed as part of the CardinalKit project at Stanford.
+See [CONTRIBUTORS.md](https://github.com/CardinalKit/ResearchKitOnFHIR/tree/main/CONTRIBUTORS.md) for a full list of all ResearchKitOnFHIR contributors.
 
 ## Notices
 ResearchKit is a registered trademark of Apple, Inc.

--- a/Sources/FHIRQuestionnaires/Questionnaire+Resources.swift
+++ b/Sources/FHIRQuestionnaires/Questionnaire+Resources.swift
@@ -20,6 +20,13 @@ extension Questionnaire {
     /// A FHIR questionnaire demonstrating the use of a contained ValueSet
     public static var containedValueSetExample: Questionnaire = loadQuestionnaire(withName: "ContainedValueSetExample")
     
+    /// A collection of all `Questionnaire`s provided by the FHIRQuestionnaires target.
+    public static var allQuestionnaires: [Questionnaire] = [
+        .skipLogicExample,
+        .textValidationExample,
+        .containedValueSetExample
+    ]
+    
     
     private static func loadQuestionnaire(withName name: String) -> Questionnaire {
         guard let resourceURL = Bundle.module.url(forResource: name, withExtension: "json") else {


### PR DESCRIPTION
- Uses [ResearchKit 2.1.2](https://github.com/PSchmiedmayer/ResearchKit/releases/tag/2.1.2) which includes an XCFramework that also includes ARM binaries.
- Updates the example app layout to use a `NavigationView` and corresponding modifiers to use the iOS navigation view layout
- Fixes README link and reference existing [CONTRIBUTORS.md](https://github.com/CardinalKit/ResearchKitOnFHIR/blob/main/CONTRIBUTORS.md) file.

New layout:
![ResearchKitOnFHIR](https://user-images.githubusercontent.com/28656495/188278751-9c7cb77d-c92c-4e3d-9dfa-5ffd5e9fa422.png)