### PR TITLE
Adds support for `questionnaire-hidden` extension

### DIFF
--- a/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
@@ -18,6 +18,7 @@ extension QuestionnaireItem {
         static let maxDecimalPlaces = "http://hl7.org/fhir/StructureDefinition/maxDecimalPlaces"
         static let minValue = "http://hl7.org/fhir/StructureDefinition/minValue"
         static let maxValue = "http://hl7.org/fhir/StructureDefinition/maxValue"
+        static let hidden = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
     }
 
     /// Checks this QuestionnaireItem for an extension matching the given URL and then return it if it exists.
@@ -26,6 +27,17 @@ extension QuestionnaireItem {
     /// - Returns: an optional Extension if it was found.
     private func getExtensionInQuestionnaireItem(url: String) -> Extension? {
         self.`extension`?.first(where: { $0.url.value?.url.absoluteString == url })
+    }
+
+    /// Is the question hidden
+    /// - Returns: A boolean representing whether the question should be shown to the user
+    var hidden: Bool {
+        guard let hiddenExtension = getExtensionInQuestionnaireItem(url: SupportedExtensions.hidden),
+              case let .boolean(booleanValue) = hiddenExtension.value,
+              let isHidden = booleanValue.value?.bool as? Bool else {
+            return false
+        }
+        return isHidden
     }
 
     /// The minimum value for a numerical answer.

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -21,7 +21,8 @@ extension Array where Element == QuestionnaireItem {
         surveySteps.reserveCapacity(self.count)
 
         for question in self {
-            guard let questionType = question.type.value else {
+            guard let questionType = question.type.value,
+                  !question.hidden else {
                 continue
             }
 
@@ -214,6 +215,7 @@ extension QuestionnaireItem {
                 let valueCoding: NSDictionary = [
                     "id": coding.id?.value?.string,
                     "display": display,
+                    "code": code,
                     "code": code,
                     "system": coding.system?.value?.url
                 ]

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -216,7 +216,6 @@ extension QuestionnaireItem {
                     "id": coding.id?.value?.string,
                     "display": display,
                     "code": code,
-                    "code": code,
                     "system": coding.system?.value?.url
                 ]
                 let choice = ORKTextChoice(text: display, value: valueCoding as NSCoding & NSCopying & NSObjectProtocol)


### PR DESCRIPTION
Adds support for the `questionnaire-hidden` (http://hl7.org/fhir/R4B/extension-questionnaire-hidden.html) extension which can be used on Questionnaire.item to prevent the question from being displayed to the user.