### PR TITLE
Add Glasgow Coma Scale

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,8 @@ let package = Package(
                 .copy("Resources/TextValidationExample.json"),
                 .copy("Resources/ContainedValueSetExample.json"),
                 .copy("Resources/NumberExample.json"),
-                .copy("Resources/PHQ-9.json")
+                .copy("Resources/PHQ-9.json"),
+                .copy("Resources/GCS.json")
             ]
         ),
         .testTarget(

--- a/Sources/FHIRQuestionnaires/Questionnaire+Resources.swift
+++ b/Sources/FHIRQuestionnaires/Questionnaire+Resources.swift
@@ -25,6 +25,9 @@ extension Questionnaire {
 
     /// The PHQ-9 validated clinical questionnaire
     public static var phq9: Questionnaire = loadQuestionnaire(withName: "PHQ-9")
+
+    /// The Glasgow Coma Scale
+    public static var gcs: Questionnaire = loadQuestionnaire(withName: "GCS")
     
     /// A collection of all `Questionnaire`s provided by the FHIRQuestionnaires target.
     public static var allQuestionnaires: [Questionnaire] = [
@@ -32,7 +35,8 @@ extension Questionnaire {
         .textValidationExample,
         .containedValueSetExample,
         .numberExample,
-        .phq9
+        .phq9,
+        .gcs
     ]
     
     

--- a/Sources/FHIRQuestionnaires/Resources/GCS.json
+++ b/Sources/FHIRQuestionnaires/Resources/GCS.json
@@ -1,0 +1,157 @@
+{
+  "resourceType" : "Questionnaire",
+  "id" : "gcs",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource &quot;gcs&quot; </p></div><p><b>url</b>: <code>http://hl7.org/fhir/Questionnaire/gcs</code></p><p><b>title</b>: Glasgow Coma Score</p><p><b>status</b>: draft</p><p><b>subjectType</b>: Patient</p><p><b>date</b>: 2015-08-03</p><p><b>publisher</b>: FHIR Project team</p><p><b>code</b>: Glasgow coma score total (Details: LOINC code 9269-2 = 'Glasgow coma score total', stated as 'null')</p><blockquote><p><b>item</b></p><p><b>linkId</b>: 1.1</p><p><b>code</b>: Glasgow coma score verbal (Details: LOINC code 9270-0 = 'Glasgow coma score verbal', stated as 'null')</p><p><b>type</b>: choice</p><p><b>answerValueSet</b>: <code>#verbal</code></p></blockquote><blockquote><p><b>item</b></p><p><b>linkId</b>: 1.2</p><p><b>code</b>: Glasgow coma score motor (Details: LOINC code 9268-4 = 'Glasgow coma score motor', stated as 'null')</p><p><b>type</b>: choice</p><p><b>answerValueSet</b>: <code>#motor</code></p></blockquote><blockquote><p><b>item</b></p><p><b>linkId</b>: 1.3</p><p><b>code</b>: Glasgow coma score eye opening (Details: LOINC code 9267-6 = 'Glasgow coma score eye opening', stated as 'null')</p><p><b>type</b>: choice</p><p><b>answerValueSet</b>: <code>#eye</code></p></blockquote></div>"
+  },
+  "contained" : [{
+    "resourceType" : "ValueSet",
+    "id" : "motor",
+    "identifier" : [{
+      "system" : "http://loinc.org",
+      "value" : "http://loinc.org/ValueSet/LL357-5"
+    }],
+    "name" : "GCS Motor Value Set",
+    "status" : "active",
+    "description" : "LOINC ANSWER LIST    (LL357-5)",
+    "compose" : {
+      "include" : [{
+        "system" : "http://loinc.org",
+        "concept" : [{
+          "code" : "LA6562-8",
+          "display" : "No motor response"
+        },
+        {
+          "code" : "LA6563-6",
+          "display" : "Extension to pain"
+        },
+        {
+          "code" : "LA6564-4",
+          "display" : "Flexion to pain"
+        },
+        {
+          "code" : "LA6565-1",
+          "display" : "Withdrawl from pain"
+        },
+        {
+          "code" : "LA6566-9",
+          "display" : "Localizing pain"
+        },
+        {
+          "code" : "LA6567-7",
+          "display" : "Obeys commands"
+        }]
+      }]
+    }
+  },
+  {
+    "resourceType" : "ValueSet",
+    "id" : "verbal",
+    "identifier" : [{
+      "system" : "http://loinc.org",
+      "value" : "http://loinc.org/ValueSet/LL356-7"
+    }],
+    "name" : "GCS Verbal Value Set",
+    "status" : "active",
+    "description" : "LOINC ANSWER LIST    (LL356-7)",
+    "compose" : {
+      "include" : [{
+        "system" : "http://loinc.org",
+        "concept" : [{
+          "code" : "LA6557-8",
+          "display" : "No verbal response (>2yrs); no vocal response (<=2yrs)"
+        },
+        {
+          "code" : "LA6558-6",
+          "display" : "Incomprehensible sounds"
+        },
+        {
+          "code" : "LA6559-4",
+          "display" : "Inappropriate words"
+        },
+        {
+          "code" : "LA6560-2",
+          "display" : "Confused"
+        },
+        {
+          "code" : "LA6561-0",
+          "display" : "Oriented"
+        }]
+      }]
+    }
+  },
+  {
+    "resourceType" : "ValueSet",
+    "id" : "eye",
+    "identifier" : [{
+      "system" : "http://loinc.org",
+      "value" : "http://loinc.org/ValueSet/LL355-9"
+    }],
+    "name" : "GCS Eye Value Set",
+    "status" : "active",
+    "description" : "LOINC ANSWER LIST    (LL355-9)",
+    "compose" : {
+      "include" : [{
+        "system" : "http://loinc.org",
+        "concept" : [{
+          "code" : "LA6553-7",
+          "display" : "No eye opening"
+        },
+        {
+          "code" : "LA6554-5",
+          "display" : "Eye opening to pain"
+        },
+        {
+          "code" : "LA6555-2",
+          "display" : "Eye opening to verbal command"
+        },
+        {
+          "code" : "LA6556-0",
+          "display" : "Eyes open spontaneously"
+        }]
+      }]
+    }
+  }],
+  "url" : "http://hl7.org/fhir/Questionnaire/gcs",
+  "title" : "Glasgow Coma Score",
+  "status" : "draft",
+  "experimental" : true,
+  "subjectType" : ["Patient"],
+  "date" : "2015-08-03",
+  "publisher" : "FHIR Project team",
+  "code" : [{
+    "system" : "http://loinc.org",
+    "code" : "9269-2"
+  }],
+  "item" : [{
+    "linkId" : "1.1",
+    "code" : [{
+      "system" : "http://loinc.org",
+      "code" : "9270-0"
+    }],
+    "type" : "choice",
+    "text" : "Best verbal response",
+    "answerValueSet" : "#verbal"
+  },
+  {
+    "linkId" : "1.2",
+    "code" : [{
+      "system" : "http://loinc.org",
+      "code" : "9268-4"
+    }],
+    "type" : "choice",
+    "text" : "Best motor response",
+    "answerValueSet" : "#motor"
+  },
+  {
+    "linkId" : "1.3",
+    "code" : [{
+      "system" : "http://loinc.org",
+      "code" : "9267-6"
+    }],
+    "type" : "choice",
+    "text" : "Best eye response",
+    "answerValueSet" : "#eye"
+  }]
+}

--- a/Sources/FHIRQuestionnaires/Resources/GCS.json.license
+++ b/Sources/FHIRQuestionnaires/Resources/GCS.json.license
@@ -1,0 +1,5 @@
+This source file is part of the ResearchKitOnFHIR open source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -60,11 +60,11 @@ extension QuestionnaireItem {
     ///   - valueSets: An array of `ValueSet` items containing sets of answer choices
     /// - Returns: An `ORKQuestionStep` object (a ResearchKit question step containing the above question).
     fileprivate func toORKQuestionStep(title: String, valueSets: [ValueSet]) -> ORKQuestionStep? {
-        guard let questionText = text?.value?.string,
-              let identifier = linkId.value?.string else {
+        guard let identifier = linkId.value?.string else {
             return nil
         }
 
+        let questionText = text?.value?.string ?? ""
         let answer = try? self.toORKAnswerFormat(valueSets: valueSets)
         return ORKQuestionStep(identifier: identifier, title: title, question: questionText, answer: answer)
     }


### PR DESCRIPTION
This PR adds the Glasgow Coma Scale based on the example in the HL7 SDC implementation guide: http://build.fhir.org/questionnaire-example-gcs.json.html. This version adds question text for each item, which the original did not have. 