### PR TITLE
Fixes issue #26 where questions with only answer options are not rendered

### DIFF
--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -60,11 +60,11 @@ extension QuestionnaireItem {
     ///   - valueSets: An array of `ValueSet` items containing sets of answer choices
     /// - Returns: An `ORKQuestionStep` object (a ResearchKit question step containing the above question).
     fileprivate func toORKQuestionStep(title: String, valueSets: [ValueSet]) -> ORKQuestionStep? {
-        guard let questionText = text?.value?.string,
-              let identifier = linkId.value?.string else {
+        guard let identifier = linkId.value?.string else {
             return nil
         }
 
+        let questionText = text?.value?.string ?? ""
         let answer = try? self.toORKAnswerFormat(valueSets: valueSets)
         return ORKQuestionStep(identifier: identifier, title: title, question: questionText, answer: answer)
     }


### PR DESCRIPTION
This addresses an issue rendering the GCS questionnaire found in the HL7 SDC implementation guide: http://build.fhir.org/questionnaire-example-gcs.json.html, where the QuestionnaireItems have answer choices, but the question text is empty.