### PR TITLE
Update navigation rules to match code and system for text choices

### DIFF
--- a/Sources/FHIRQuestionnaires/Resources/SkipLogicExample.json
+++ b/Sources/FHIRQuestionnaires/Resources/SkipLogicExample.json
@@ -50,66 +50,61 @@
       "required": true
     },
     {
-      "linkId": "169e7113-1e8f-4858-fc97-5703ba865703",
-      "type": "group",
-      "text": "Tell us more about your interest in ice cream.",
+      "linkId": "59e7a3f7-4108-47a7-8fae-0fb892574a63",
+      "type": "choice",
+      "text": "What is your favorite flavor?",
+      "required": false,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "460afea8-2634-4bb4-89d2-001d92624d6c",
+            "code": "chocolate",
+            "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
+            "display": "Chocolate"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "6fef1216-0b74-40bd-e773-2bd4a7f66e45",
+            "code": "vanilla",
+            "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
+            "display": "Vanilla"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "abc0a0bf-0e35-48db-8f0f-b2d30038816b",
+            "code": "strawberry",
+            "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
+            "display": "Strawberry"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "d1c27eeb-022a-4ef9-8f70-068d96a26154",
+            "code": "other",
+            "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
+            "display": "Other"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "7d7695e1-741b-4a4b-b479-a9908f86cf55",
+      "type": "date",
+      "text": "When did you last have chocolate ice cream?",
       "required": false,
       "enableWhen": [
         {
-          "question": "f0f95365-96d2-4892-9ccf-2e2c0c74a87c",
+          "question": "59e7a3f7-4108-47a7-8fae-0fb892574a63",
           "operator": "=",
-          "answerBoolean": true
+          "answerCoding": {
+            "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
+            "code": "chocolate"
+          }
         }
       ],
-      "item": [
-        {
-          "linkId": "59e7a3f7-4108-47a7-8fae-0fb892574a63",
-          "type": "choice",
-          "text": "What is your favorite flavor?",
-          "required": false,
-          "answerOption": [
-            {
-              "valueCoding": {
-                "id": "460afea8-2634-4bb4-89d2-001d92624d6c",
-                "code": "chocolate",
-                "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
-                "display": "Chocolate"
-              }
-            },
-            {
-              "valueCoding": {
-                "id": "6fef1216-0b74-40bd-e773-2bd4a7f66e45",
-                "code": "vanilla",
-                "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
-                "display": "Vanilla"
-              }
-            },
-            {
-              "valueCoding": {
-                "id": "abc0a0bf-0e35-48db-8f0f-b2d30038816b",
-                "code": "strawberry",
-                "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
-                "display": "Strawberry"
-              }
-            },
-            {
-              "valueCoding": {
-                "id": "d1c27eeb-022a-4ef9-8f70-068d96a26154",
-                "code": "other",
-                "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
-                "display": "Other"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "7d7695e1-741b-4a4b-b479-a9908f86cf55",
-          "type": "date",
-          "text": "When did you last have it?",
-          "required": false
-        }
-      ]
+      "enableBehavior": "all"
     }
   ]
 }
-

--- a/Sources/FHIRQuestionnaires/Resources/SkipLogicExample.json
+++ b/Sources/FHIRQuestionnaires/Resources/SkipLogicExample.json
@@ -87,12 +87,19 @@
             "display": "Other"
           }
         }
+      ],
+      "enableWhen": [
+        {
+          "question": "f0f95365-96d2-4892-9ccf-2e2c0c74a87c",
+          "operator": "=",
+          "answerBoolean": true
+        }
       ]
     },
     {
-      "linkId": "7d7695e1-741b-4a4b-b479-a9908f86cf55",
-      "type": "date",
-      "text": "When did you last have chocolate ice cream?",
+      "linkId": "b950aeb7-a7cd-4472-901b-210c0296492b",
+      "type": "string",
+      "text": "Enter in your favorite flavor",
       "required": false,
       "enableWhen": [
         {
@@ -100,8 +107,22 @@
           "operator": "=",
           "answerCoding": {
             "system": "urn:uuid:ea53f9f1-4c06-4953-83b6-c944bccdeae3",
-            "code": "chocolate"
+            "code": "other"
           }
+        }
+      ],
+      "enableBehavior": "all"
+    },
+    {
+      "linkId": "5699c117-70e4-4849-f89f-c3591c090381",
+      "type": "date",
+      "text": "When did you last have this flavor?",
+      "required": false,
+      "enableWhen": [
+        {
+          "question": "59e7a3f7-4108-47a7-8fae-0fb892574a63",
+          "operator": "exists",
+          "answerBoolean": true
         }
       ],
       "enableBehavior": "all"

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -25,7 +25,7 @@ extension ORKNavigableOrderedTask {
                 guard let predicate = try fhirPredicate.predicate else {
                     continue
                 }
-                
+
                 self.setSkip(ORKPredicateSkipStepNavigationRule(resultPredicate: predicate), forStepIdentifier: questionId)
             }
         }
@@ -73,14 +73,19 @@ extension Decimal {
 
 extension Coding {
     fileprivate func predicate(with resultSelector: ORKResultSelector, operator fhirOperator: QuestionnaireItemOperator) throws -> NSPredicate? {
-        guard let matchValue = code?.value?.string else {
+        guard let code = code?.value?.string,
+              let system = system?.value?.url else {
             return nil
         }
         
         switch fhirOperator {
         case .equal:
-            let matchingPattern = "^(?!\(matchValue)).*$"
-            return ORKResultPredicate.predicateForChoiceQuestionResult(with: resultSelector, matchingPattern: matchingPattern)
+            let expectedAnswerValue: NSDictionary = [
+                "code": code,
+                "system": system,
+            ]
+            let predicate = ORKResultPredicate.predicateForChoiceQuestionResult(with: resultSelector, expectedAnswerValue: expectedAnswerValue as NSCoding & NSCopying & NSObjectProtocol)
+            return NSCompoundPredicate(notPredicateWithSubpredicate: predicate)
         default:
             throw FHIRToResearchKitConversionError.unsupportedOperator(fhirOperator)
         }

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -80,11 +80,13 @@ extension Coding {
         
         switch fhirOperator {
         case .equal:
-            let expectedAnswerValue: NSDictionary = [
+            let expectedAnswer: NSDictionary = [
                 "code": code,
-                "system": system,
+                "system": system
             ]
-            let predicate = ORKResultPredicate.predicateForChoiceQuestionResult(with: resultSelector, expectedAnswerValue: expectedAnswerValue as NSCoding & NSCopying & NSObjectProtocol)
+            let predicate = ORKResultPredicate.predicateForChoiceQuestionResult(with: resultSelector,
+                                                                                expectedAnswerValue: expectedAnswer
+                                                                                    as NSCoding & NSCopying & NSObjectProtocol)
             return NSCompoundPredicate(notPredicateWithSubpredicate: predicate)
         default:
             throw FHIRToResearchKitConversionError.unsupportedOperator(fhirOperator)

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -191,8 +191,6 @@ extension QuestionnaireItem {
                     continue
                 }
                 let valueCoding: NSDictionary = [
-                    "id": option.id?.value?.string,
-                    "display": display,
                     "code": code,
                     "system": valueSet?.compose?.include.first?.system?.value?.url
                 ]
@@ -213,8 +211,6 @@ extension QuestionnaireItem {
                     continue
                 }
                 let valueCoding: NSDictionary = [
-                    "id": coding.id?.value?.string,
-                    "display": display,
                     "code": code,
                     "system": coding.system?.value?.url
                 ]


### PR DESCRIPTION
- Previously when we created navigation rules that matched a specific text choice (representing a FHIR `Coding`), the ORKTextChoice would record only a string with the `code` in the result object, but as of PR #20 the ORKTextChoice records a dictionary in the result object that contains both the `code` and the `system` and so we need to match both when constructing our navigation rule.
- The `id` and `display` elements were removed from the result dictionary, because these are not necessary in the QuestionnaireResponse, and impede matching in navigation rules since they are not present in the `enableWhen` expressions generated by our Survey Builder.